### PR TITLE
Support for multiple mealtime schedule

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -21,10 +21,10 @@ class Extension extends BaseExtension
             if (!$isAvailable)
                 return;
 
-            $mealtimeNotAvailable = false;
+            $mealtimeNotAvailable = true;
             $model->mealtimes->each(function($mealtime) use (&$mealtimeNotAvailable, $dateTime){
-                if (!$mealtime->isAvailableSchedule($dateTime))
-                    $mealtimeNotAvailable = true;
+                if ($mealtime->isAvailableSchedule($dateTime))
+                    $mealtimeNotAvailable = false;
             });
 
             if ($mealtimeNotAvailable)


### PR DESCRIPTION
Change the logic to initially assume all mealtime schedules assigned to an item is unavailable. Then test if any of them are actually available using isAvailableSchedule().

This approach will allow items with multiple mealtime schedules assigned to available even if one schedule is unavailable.